### PR TITLE
Improve contrast of Chrome extension notice in dark mode

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -99,10 +99,34 @@ function Home({ user }) {
         )}
 
         {/* Chrome Extension Notice */}
-        <Box w="full" maxW="2xl" mx="auto" mt={12} bg="blue.50" _dark={{ bg: "blue.900" }} borderRadius="md" px={4} py={3} border="1px solid" borderColor="blue.200" _dark={{ borderColor: "blue.700" }}>
-          <Text fontSize="md" color="blue.800" _dark={{ color: "blue.200" }}>
+        <Box
+          w="full"
+          maxW="2xl"
+          mx="auto"
+          mt={12}
+          bg="blue.100"
+          borderRadius="md"
+          px={4}
+          py={3}
+          border="1px solid"
+          borderColor="blue.300"
+          _dark={{ 
+            bg: "blue.800",
+            borderColor: "blue.600" 
+          }}
+        >
+          <Text fontSize="md" color="blue.900" _dark={{ color: "blue.100" }}>
             We also provide a <b>Chrome extension</b> for highlighting cheaters directly on Codeforces. <br />
-            <a href="https://github.com/macaquedev/cf-cheater-highlighter" target="_blank" rel="noopener noreferrer" style={{ color: '#2b6cb0', textDecoration: 'underline' }}>
+            <a
+              href="https://github.com/macaquedev/cf-cheater-highlighter"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: '#1a73e8', // brighter link color
+                textDecoration: 'underline',
+                fontWeight: '500',
+              }}
+            >
               Get it here on GitHub
             </a>.
           </Text>


### PR DESCRIPTION
## 🛠️ Improve Contrast of Chrome Extension Notice (Dark Mode)

### 🔍 Summary
This PR improves the contrast of the Chrome extension notice banner in dark mode, addressing readability issues with the previous low-contrast text and background. The new design improves accessibility while keeping a consistent theme.

### 🖼️ Before
#### Dark Mode
![Screenshot 2025-06-25 213006](https://github.com/user-attachments/assets/b10f1323-4582-4646-b562-251198bd6f52)

### 🖼️ After
#### Dark Mode
![Screenshot 2025-06-25 213021](https://github.com/user-attachments/assets/fea5658c-1ab2-4170-9e5c-602a44caf924)